### PR TITLE
fix(compass-ui): increase maximum size limits for component styles

### DIFF
--- a/components/compass-ui/angular.json
+++ b/components/compass-ui/angular.json
@@ -40,8 +40,8 @@
               },
               {
                 "type": "anyComponentStyle",
-                "maximumWarning": "25kb",
-                "maximumError": "30kb"
+                "maximumWarning": "35kb",
+                "maximumError": "40kb"
               }
             ]
           },
@@ -55,8 +55,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "25kb",
-                  "maximumError": "30kb"
+                  "maximumWarning": "35kb",
+                  "maximumError": "40kb"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
- Updated maximumWarning and maximumError size limits for anyComponentStyle in angular.json from 25kb/30kb to 35kb/40kb to allow for larger component styles.