### PR TITLE
fix(layout): update default logo and application name for initial setup

### DIFF
--- a/components/compass-ui/src/app/core/layout/layout.component.ts
+++ b/components/compass-ui/src/app/core/layout/layout.component.ts
@@ -48,10 +48,10 @@ export class LayoutComponent implements OnInit, OnDestroy {
   // Initialize with empty values
   config = {
     logo: {
-      path: "assets/logo.svg", // Default logo path
+      path: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", // Default logo path, transparent pixel
       alt: "App Logo",
     },
-    name: "Application", // Default app name
+    name: "", // Default app name
     navigation: [] as NavigationItem[],
     footer: {
       aboutText: "",


### PR DESCRIPTION
- Changed the default logo path to a transparent pixel for a cleaner initial appearance.
- Updated the application name to an empty string to allow for dynamic naming during setup.