### PR TITLE
fix(tech-radar): remove EXIT label from radar visualization

### DIFF
--- a/components/compass-ui/src/assets/tech-radar.svg
+++ b/components/compass-ui/src/assets/tech-radar.svg
@@ -13,8 +13,6 @@
   <text x="400" y="100" fill="#64748b" font-size="14">TRIAL</text>
   <text x="200" y="300" fill="#64748b" font-size="14">HOLD</text>
   <text x="400" y="300" fill="#64748b" font-size="14">ADOPT</text>
-  <text x="400" y="300" fill="#64748b" font-size="14">EXIT</text>
-
 
   <!-- Technology dots and labels -->
   <g>


### PR DESCRIPTION
- Eliminated the EXIT label from the Tech Radar SVG to streamline the display and improve clarity in the representation of technology categories.